### PR TITLE
Fix xz decompression in bmap-writer

### DIFF
--- a/bmap-writer-test.sh
+++ b/bmap-writer-test.sh
@@ -31,6 +31,6 @@ echo "## Write the file with bmap-writer and gzip"
 ./bmap-writer test.img.gz test.img.bmap test.gz.img.out
 cmp test.img.out test.gz.img.out
 
-# echo "## Write the file with bmap-writer and xz"
-# ./bmap-writer test.img.xz test.img.bmap test.xz.img.out
-# cmp test.img.out test.xz.img.out
+echo "## Write the file with bmap-writer and xz"
+./bmap-writer test.img.xz test.img.bmap test.xz.img.out
+cmp test.img.out test.xz.img.out

--- a/bmap-writer-test.sh
+++ b/bmap-writer-test.sh
@@ -34,3 +34,11 @@ cmp test.img.out test.gz.img.out
 echo "## Write the file with bmap-writer and xz"
 ./bmap-writer test.img.xz test.img.bmap test.xz.img.out
 cmp test.img.out test.xz.img.out
+
+echo "## Verify the xz decompression test passes"
+if cmp -s test.img.out test.xz.img.out; then
+    echo "xz decompression test passed"
+else
+    echo "xz decompression test failed"
+    exit 1
+fi

--- a/bmap-writer.cpp
+++ b/bmap-writer.cpp
@@ -233,7 +233,6 @@ int BmapWriteImage(const std::string &imageFile, const bmap_t &bmap, const std::
                 return 1;
             }
             bytesRead = static_cast<size_t>(readBytes);
-        // ToDO: Fix support for xz decompression
         } else if (compressionType == "xz") {
             imgFile.seekg(static_cast<std::streamoff>(startBlock * bmap.blockSize), std::ios::beg);
             imgFile.read(buffer.data(), static_cast<std::streamsize>(bufferSize));
@@ -256,6 +255,7 @@ int BmapWriteImage(const std::string &imageFile, const bmap_t &bmap, const std::
                 imgFile.close();
                 return 1;
             }
+            bytesRead = bufferSize - lzmaStream.avail_out;
         } else if (compressionType == "none") {
             imgFile.seekg(static_cast<std::streamoff>(startBlock * bmap.blockSize), std::ios::beg);
             imgFile.read(buffer.data(), static_cast<std::streamsize>(bufferSize));

--- a/bmap-writer.cpp
+++ b/bmap-writer.cpp
@@ -248,12 +248,14 @@ int BmapWriteImage(const std::string &imageFile, const bmap_t &bmap, const std::
             lzmaStream.next_out = reinterpret_cast<uint8_t*>(buffer.data());
             lzmaStream.avail_out = bufferSize;
 
-            lzma_ret ret = lzma_code(&lzmaStream, LZMA_RUN);
-            if (ret != LZMA_OK && ret != LZMA_STREAM_END) {
-                std::cerr << "Failed to decompress xz image file: " << ret << std::endl;
-                close(dev_fd);
-                imgFile.close();
-                return 1;
+            while (lzmaStream.avail_in > 0) {
+                lzma_ret ret = lzma_code(&lzmaStream, LZMA_RUN);
+                if (ret != LZMA_OK && ret != LZMA_STREAM_END) {
+                    std::cerr << "Failed to decompress xz image file: " << ret << std::endl;
+                    close(dev_fd);
+                    imgFile.close();
+                    return 1;
+                }
             }
             bytesRead = bufferSize - lzmaStream.avail_out;
         } else if (compressionType == "none") {


### PR DESCRIPTION
Related to #1

Fix xz decompression in `bmap-writer.cpp` and update tests in `bmap-writer-test.sh`.

* **bmap-writer.cpp**
  - Remove TODO comment indicating xz decompression needs fixing.
  - Properly handle xz decompression in `BmapWriteImage` function by updating the bytesRead calculation.

* **bmap-writer-test.sh**
  - Uncomment the xz decompression test.
  - Ensure the xz decompression test is passing.

