### PR TITLE
Fix build failure due to mismatched options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 
 # Add the executable
 add_executable(bmap-writer bmap-writer.cpp)
-target_compile_options(bmap-writer PUBLIC -Wformat-security -Wconversion -Wsign-conversion -pedantic -Werror)
+target_compile_options(bmap-writer PUBLIC -Wformat -Wformat-security -Wconversion -Wsign-conversion -pedantic -Werror)
 
 # Link the libraries
 target_link_libraries(bmap-writer ${LIBXML2_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES} ${LIBLZMA_LIBRARIES})


### PR DESCRIPTION
Ifi the -Wformat-security option is specified without -Wformat, the compiler can throw a warning, which then becomes an error due to -Werror.

Add -Wformat to the compile options, retaining the original functionality while allowing the build to complete.
