### PR TITLE
Add support for Zstandard and write with O_SYNC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,21 @@ else()
     message(FATAL_ERROR "liblzma not found")
 endif()
 
+# Find libzstd
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(ZSTD REQUIRED IMPORTED_TARGET libzstd)
+if (ZSTD_FOUND)
+    include_directories(${ZSTD_INCLUDE_DIRS})
+else()
+    message(FATAL_ERROR "libzstd not found")
+endif()
+
 # Add the executable
 add_executable(bmap-writer bmap-writer.cpp)
 target_compile_options(bmap-writer PUBLIC -Wformat -Wformat-security -Wconversion -Wsign-conversion -pedantic -Werror)
 
 # Link the libraries
-target_link_libraries(bmap-writer ${LIBXML2_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES} ${LIBLZMA_LIBRARIES})
+target_link_libraries(bmap-writer ${LIBXML2_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES} ${LIBLZMA_LIBRARIES} ${ZSTD_LIBRARIES})
 
 # Specify the install rules
 install(TARGETS bmap-writer DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unlike the Yocto BMAP tool, `bmap-writer` is C++ based does not require Python a
 
 - **Alternative to Yocto BMAP Tool**: Provides a lightweight alternative specifically for embedded systems.
 - **No Python Required**: Does not require Python, making it easier to integrate into various environments.
-- **Support for Compressed Images**: Handles gzip and xz compressed images, decompressing them on-the-fly during the writing process.
+- **Support for Compressed Images**: Handles gzip, xz anz zstd compressed images, decompressing them on-the-fly during the writing process.
 - **Checksum Verification**: Ensures data integrity by verifying checksums for each block.
 - **Efficient Writing**: Writes only the necessary blocks, reducing the overall write time and wear on storage devices.
 

--- a/bmap-writer-test.sh
+++ b/bmap-writer-test.sh
@@ -10,10 +10,19 @@ if [ ! -f test.img ]; then
     dd if=/dev/urandom of=test.img bs=4k count=1 seek=131072 conv=notrunc  > /dev/null 2>&1
 fi
 
-if [ ! -f test.img.gz ] || [ ! -f test.img.xz ]; then
-    echo "## Compress the file with xz and gzip"
-    xz   -z test.img -c   > test.img.xz
+if [ ! -f test.img.gz ]; then
+    echo "## Compress the file with gzip"
     gzip -9 test.img -c   > test.img.gz
+fi
+
+if [ ! -f test.img.xz ]; then
+    echo "## Compress the file with xz"
+    xz   -z test.img -c   > test.img.xz
+fi
+
+if [ ! -f test.img.zst ]; then
+    echo "## Compress the file with zstd"
+    zstd -f -k -c -3 --threads=8 test.img > test.img.zst
 fi
 
 if [ ! -f test.img.bmap ] ; then
@@ -35,3 +44,7 @@ cmp test.img.out test.gz.img.out
 echo "## Write the file with bmap-writer and xz"
 ./bmap-writer test.img.xz test.img.bmap test.xz.img.out
 cmp test.img.out test.xz.img.out
+
+echo "## Write the file with bmap-writer and zstd"
+./bmap-writer test.img.zst test.img.bmap test.zst.img.out
+cmp test.img.out test.zst.img.out

--- a/bmap-writer.cpp
+++ b/bmap-writer.cpp
@@ -193,7 +193,7 @@ int BmapWriteImage(const std::string &imageFile, const bmap_t &bmap, const std::
     int ret = 0;
 
     try {
-        dev_fd = open(device.c_str(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+        dev_fd = open(device.c_str(), O_WRONLY | O_CREAT | O_SYNC, S_IRUSR | S_IWUSR);
         if (dev_fd < 0) {
             throw std::string("Unable to open or create target device");
         }


### PR DESCRIPTION
- Add support for dis images compressed with Zstandard.
- Open target device with O_SYNC, to avoid excessive caching by the OS.

