### PR TITLE
Move to libarchive

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get --no-install-recommends install -y bmap-tools libssl-dev libxml2-dev zlib1g-dev liblzma-dev cppcheck
+      run: sudo apt-get update && sudo apt-get --no-install-recommends install -y bmap-tools libssl-dev libxml2-dev libarchive-dev tar bzip2 gzip lz4 lzop xz-utils zstd  cppcheck
 
     - name: Cppcheck
       run: cppcheck --enable=all --suppress=missingIncludeSystem *.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,29 +23,12 @@ else()
     message(FATAL_ERROR "OpenSSL not found")
 endif()
 
-# Find zlib
-find_package(ZLIB REQUIRED)
-if (ZLIB_FOUND)
-    include_directories(${ZLIB_INCLUDE_DIRS})
+# Find libarchive
+find_package(LibArchive REQUIRED)
+if (LibArchive_FOUND)
+    include_directories(${LIBARCHIVE_INCLUDE_DIR})
 else()
-    message(FATAL_ERROR "zlib not found")
-endif()
-
-# Find liblzma
-find_package(LibLZMA REQUIRED)
-if (LIBLZMA_FOUND)
-    include_directories(${LIBLZMA_INCLUDE_DIRS})
-else()
-    message(FATAL_ERROR "liblzma not found")
-endif()
-
-# Find libzstd
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(ZSTD REQUIRED IMPORTED_TARGET libzstd)
-if (ZSTD_FOUND)
-    include_directories(${ZSTD_INCLUDE_DIRS})
-else()
-    message(FATAL_ERROR "libzstd not found")
+    message(FATAL_ERROR "libarchive not found")
 endif()
 
 # Add the executable
@@ -53,7 +36,7 @@ add_executable(bmap-writer bmap-writer.cpp)
 target_compile_options(bmap-writer PUBLIC -Wformat -Wformat-security -Wconversion -Wsign-conversion -pedantic -Werror)
 
 # Link the libraries
-target_link_libraries(bmap-writer ${LIBXML2_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES} ${LIBLZMA_LIBRARIES} ${ZSTD_LIBRARIES})
+target_link_libraries(bmap-writer ${LIBXML2_LIBRARIES} ${OPENSSL_LIBRARIES} ${LibArchive_LIBRARIES})
 
 # Specify the install rules
 install(TARGETS bmap-writer DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unlike the Yocto BMAP tool, `bmap-writer` is C++ based does not require Python a
 
 - **Alternative to Yocto BMAP Tool**: Provides a lightweight alternative specifically for embedded systems.
 - **No Python Required**: Does not require Python, making it easier to integrate into various environments.
-- **Support for Compressed Images**: Handles gzip, xz anz zstd compressed images, decompressing them on-the-fly during the writing process.
+- **Support for Compressed Images**: Handles all compression filters that are supported by `libarchive`, decompressing the data on-the-fly during the writing process.
 - **Checksum Verification**: Ensures data integrity by verifying checksums for each block.
 - **Efficient Writing**: Writes only the necessary blocks, reducing the overall write time and wear on storage devices.
 

--- a/bmap-writer-test.sh
+++ b/bmap-writer-test.sh
@@ -10,9 +10,34 @@ if [ ! -f test.img ]; then
     dd if=/dev/urandom of=test.img bs=4k count=1 seek=131072 conv=notrunc  > /dev/null 2>&1
 fi
 
+if [ ! -f test.img.tar ]; then
+    echo "## Enclose the file inside tar"
+    tar -cf test.img.tar test.img
+fi
+
+if [ ! -f test.img.tar.gz ]; then
+    echo "## Enclose the file inside tar.gz"
+    tar -czf test.img.tar.gz test.img
+fi
+
+if [ ! -f test.img.bz2 ]; then
+    echo "## Compress the file with bzip2"
+    bzip2 -f -k -c test.img > test.img.bz2
+fi
+
 if [ ! -f test.img.gz ]; then
     echo "## Compress the file with gzip"
     gzip -9 test.img -c   > test.img.gz
+fi
+
+if [ ! -f test.img.lz4 ]; then
+    echo "## Compress the file with lz4"
+    lz4 -f -k -c test.img > test.img.lz4
+fi
+
+if [ ! -f test.img.lzo ]; then
+    echo "## Compress the file with lzo"
+    lzop -f -k -c test.img > test.img.lzo
 fi
 
 if [ ! -f test.img.xz ]; then
@@ -22,7 +47,7 @@ fi
 
 if [ ! -f test.img.zst ]; then
     echo "## Compress the file with zstd"
-    zstd -f -k -c -3 --threads=8 test.img > test.img.zst
+    zstd -f -k -c test.img > test.img.zst
 fi
 
 if [ ! -f test.img.bmap ] ; then
@@ -37,9 +62,29 @@ echo "## Write the file with bmap-writer"
 ./bmap-writer test.img test.img.bmap test.none.img.out
 cmp test.img.out test.none.img.out
 
+echo "## Write the file with bmap-writer and tar"
+./bmap-writer test.img.tar test.img.bmap test.tar.img.out
+cmp test.img.out test.tar.img.out
+
+echo "## Write the file with bmap-writer and tar+gzip"
+./bmap-writer test.img.tar.gz test.img.bmap test.tar.gz.img.out
+cmp test.img.out test.tar.gz.img.out
+
+echo "## Write the file with bmap-writer and bzip2"
+./bmap-writer test.img.bz2 test.img.bmap test.bz2.img.out
+cmp test.img.out test.bz2.img.out
+
 echo "## Write the file with bmap-writer and gzip"
 ./bmap-writer test.img.gz test.img.bmap test.gz.img.out
 cmp test.img.out test.gz.img.out
+
+echo "## Write the file with bmap-writer and lz4"
+./bmap-writer test.img.lz4 test.img.bmap test.lz4.img.out
+cmp test.img.out test.lz4.img.out
+
+echo "## Write the file with bmap-writer and lzo"
+./bmap-writer test.img.lzo test.img.bmap test.lzo.img.out
+cmp test.img.out test.lzo.img.out
 
 echo "## Write the file with bmap-writer and xz"
 ./bmap-writer test.img.xz test.img.bmap test.xz.img.out


### PR DESCRIPTION
Use libarchive for all the decompression operations, in order to reduce the complexity while supporting more input formats.
