### PR TITLE
Add options to limit write buffer and modify checksum behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Unlike the Yocto BMAP tool, `bmap-writer` is C++ based does not require Python a
 
 ## Usage
 
+```sh
+bmap-writer [-n] <image-file> [bmap-file] <target-device>
 ```
-bmap-writer <image-file> [bmap-file] <target-device>
 
-```
+* `-n`: Skip checksum verification
 
 ## Yocto Integration
 

--- a/bmap-writer-test.sh
+++ b/bmap-writer-test.sh
@@ -97,3 +97,7 @@ cmp test.img.out test.zst.img.out
 echo "## Write the file with bmap-writer and zstd"
 ./bmap-writer test.img.zst test.zst.img.out
 cmp test.img.out test.zst.img.out
+
+echo "## Write the file with bmap-writer and zstd (skip checksum)"
+./bmap-writer -n test.img.zst test.zst.img.out
+cmp test.img.out test.zst.img.out


### PR DESCRIPTION
Add command line options to:

- limit write buffer size, useful on systems with limited RAM memory but large flash device(s)
- modify the checksum behavior, either verifying the written data instead of the source one or skipping the checksum entirely