### PR TITLE
Add support for reading input image from stdin

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get --no-install-recommends install -y bmap-tools libssl-dev libtinyxml2-dev libarchive-dev tar bzip2 gzip lz4 lzop xz-utils zstd  cppcheck
+      run: sudo apt-get update && sudo apt-get --no-install-recommends install -y bmap-tools libssl-dev libtinyxml2-dev libarchive-dev tar bzip2 gzip lz4 lzop xz-utils zstd python3 wget cppcheck
 
     - name: Cppcheck
       run: cppcheck --enable=all --suppress=missingIncludeSystem *.cpp

--- a/README.md
+++ b/README.md
@@ -62,11 +62,38 @@ sudo make install
 ## Usage
 
 ```sh
-bmap-writer [-n] <image-file> [bmap-file] <target-device>
+bmap-writer [-hvn] <image-file> [<bmap-file>] <target-device>
 ```
 
-* `-n`: Skip checksum verification
-* `bmap-file`: Optional. If not provided, it will be searched in the same path as the input `image-file`.
+* `-n` : Skip checksum verification
+* `-v` : Show version
+* `-h` : Show this help and exit
+* `<bmap-file>`: Optional. If not provided, it will be searched in the same path as the input `<image-file>`.
+
+To use stdin as source of the image file, `<image-file>` shall be equal to `-` and `<bmap-file>` shall be present.
+
+### Streaming mode
+
+Streaming mode, i.e. writing data while it's being received, is supported through piping from external applications.
+The BMAP file shall be present and available before the data streaming is started.
+
+Some examples are presented below:
+
+* Download from an HTTP server using `wget`:
+```bash
+wget -O - http://myserver.com/image.bmap > image.bmap
+wget -O - http://myserver.com/image.gz | bmap-writer - image.bmap /dev/sdX
+```
+* Download from a FTP server using `wget`:
+```bash
+wget -O - ftp://user@myserver.com:2121/image.bmap > image.bmap
+wget -O - ftp://user@myserver.com:2121/image.gz | bmap-writer - image.bmap /dev/sdX
+```
+* Download from a SFTP host using `curl`:
+```bash
+curl -u user:password sftp://hostname/path/to/image.bmap > image.bmap
+curl -u user:password sftp://hostname/path/to/image.gz | bmap-writer - image.bmap /dev/sdX
+```
 
 ## Yocto Integration
 

--- a/bmap-writer-test.sh
+++ b/bmap-writer-test.sh
@@ -92,14 +92,30 @@ echo "## Write the file with bmap-writer and xz"
 ./bmap-writer test.img.xz test.img.bmap test.xz.img.out
 cmp test.img.out test.xz.img.out
 
+echo "## Write the file with bmap-writer and external xz (pipe mode)"
+xzcat test.img.xz | ./bmap-writer - test.img.bmap test2.xz.img.out
+cmp test.img.out test2.xz.img.out
+
 echo "## Write the file with bmap-writer and zstd"
 ./bmap-writer test.img.zst test.img.bmap test.zst.img.out
 cmp test.img.out test.zst.img.out
 
 echo "## Write the file with bmap-writer and zstd"
-./bmap-writer test.img.zst test.zst.img.out
-cmp test.img.out test.zst.img.out
+./bmap-writer test.img.zst test2.zst.img.out
+cmp test.img.out test2.zst.img.out
 
 echo "## Write the file with bmap-writer and zstd (skip checksum)"
-./bmap-writer -n test.img.zst test.zst.img.out
-cmp test.img.out test.zst.img.out
+./bmap-writer -n test.img.zst test3.zst.img.out
+cmp test.img.out test3.zst.img.out
+
+echo "## Write the file with bmap-writer and zstd (pipe mode)"
+cat test.img.zst | ./bmap-writer - test.img.bmap test4.zst.img.out
+cmp test.img.out test4.zst.img.out
+
+echo "## Write the file with bmap-writer and zstd from HTTP server"
+python3 -m http.server -d $(pwd) -b 127.0.0.1 8987 &
+SERVER_PID=$!
+sleep 2
+wget -O - http://127.0.0.1:8987/test.img.zst | ./bmap-writer - test.img.bmap test5.zst.img.out
+cmp test.img.out test5.zst.img.out
+kill $SERVER_PID

--- a/bmap-writer.cpp
+++ b/bmap-writer.cpp
@@ -196,7 +196,8 @@ int BmapWriteImage(const std::string &imageFile, const bmap_t &bmap, const std::
         struct archive_entry *ae;
         r = archive_read_next_header(a, &ae);
         if (r != ARCHIVE_OK) {
-            throw std::string("Failed to read archive header: ") + std::string(archive_error_string(a));
+            const char * aerr = archive_error_string(a);
+            throw std::string("Failed to read archive header: ") + ((aerr != nullptr) ? std::string(aerr) : "unknown error");
         }
 
         size_t totalWrittenSize = 0;


### PR DESCRIPTION
As the title suggest, add support for reading the disk image file from stdin. This allows to use other sources in addition to regular files, such as `wget` and `curl` output, opening the road to a sort of streaming mode.

Can be a solution for #15 that does not increase the complexity of bmap-writer itself.