### PR TITLE
sha256: add optional support for kernel crypto API

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get --no-install-recommends install -y bmap-tools libssl-dev libtinyxml2-dev libarchive-dev tar bzip2 gzip lz4 lzop xz-utils zstd python3 wget cppcheck
+      run: sudo apt-get update && sudo apt-get --no-install-recommends install -y bmap-tools libssl-dev libtinyxml2-dev libarchive-dev libkcapi-dev tar bzip2 gzip lz4 lzop xz-utils zstd python3 wget cppcheck
 
     - name: Cppcheck
       run: cppcheck --enable=all --suppress=missingIncludeSystem *.cpp
@@ -31,7 +31,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DUSE_KERNEL_CRYPTO_API=ON
 
     - name: Build
       # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ else()
     message(FATAL_ERROR "libarchive not found")
 endif()
 
+option(USE_KERNEL_CRYPTO_API "Use the kernel crypto API to perform the hashing")
+if(USE_KERNEL_CRYPTO_API)
+    list(APPEND CRYPTO_LIBRARIES kcapi)
+    add_compile_definitions(USE_KERNEL_CRYPTO_API)
+endif()
+
 if (NOT DEFINED DEFAULT_READ_BLK_SIZE)
   set(DEFAULT_READ_BLK_SIZE 16384)
 endif()
@@ -47,7 +53,7 @@ add_executable(bmap-writer bmap-writer.cpp sha256.cpp)
 target_compile_options(bmap-writer PUBLIC -Wformat -Wformat-security -Wconversion -Wsign-conversion -pedantic -Werror)
 
 # Link the libraries
-target_link_libraries(bmap-writer ${TINYXML2_LIBRARIES} ${LibArchive_LIBRARIES})
+target_link_libraries(bmap-writer ${TINYXML2_LIBRARIES} ${LibArchive_LIBRARIES} ${CRYPTO_LIBRARIES})
 
 # Specify the install rules
 install(TARGETS bmap-writer DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Unlike the Yocto BMAP tool, `bmap-writer` is C++ based does not require Python a
 - Handles all compression filters that are supported by `libarchive`, decompressing the data on-the-fly during the writing process.
 - Ensures data integrity by verifying checksums for each block.
 - Writes only the necessary blocks, reducing the overall write time and wear on storage devices.
+- Can use the Linux kernel crypto API to leverage hardware-accelerate hashing.
 
 ## How It Works
 
@@ -28,6 +29,7 @@ Unlike the Yocto BMAP tool, `bmap-writer` is C++ based does not require Python a
 - CMake
 - Libarchive
 - TinyXML-2
+- libkcapi (optional)
 
 ## Build and Installation
 
@@ -37,7 +39,7 @@ Unlike the Yocto BMAP tool, `bmap-writer` is C++ based does not require Python a
 
 ```sh
 sudo apt-get update
-sudo apt-get install -y libarchive-dev libtinyxml2-dev
+sudo apt-get install -y libarchive-dev libtinyxml2-dev libkcapi-dev
 ```
 
 ## Build
@@ -45,6 +47,15 @@ sudo apt-get install -y libarchive-dev libtinyxml2-dev
 ```sh
 cmake .
 make
+```
+
+### Enable support for the Linux kernel crypto API
+
+To enable support for the Linux kernel crypto API, which is disabled by default, the `USE_KERNEL_CRYPTO_API` option
+shall be set to `ON`:
+
+```sh
+cmake -DUSE_KERNEL_CRYPTO_API=ON .
 ```
 
 ## Test

--- a/bmap-writer.cpp
+++ b/bmap-writer.cpp
@@ -182,6 +182,10 @@ int checkBmap(const std::string &filename, const std::string& checksum) {
         } else {
             SHA256Ctx sha256Ctx = {};
 
+            if (sha256Init(sha256Ctx) != 0) {
+                throw std::string("Failed to initalize hasher");
+            }
+
             while (std::getline(file, line)) {
                 std::size_t found = line.find(checksum);
                 // The actual checksum of the BMAP file shall be replaced with a set of '0'
@@ -363,6 +367,10 @@ int BmapWriteImage(int fd, const bmap_t &bmap, const std::string &device, bool n
                 // Read back written data and compute checksum on it.
                 size_t readSize = 0;
                 SHA256Ctx verifySha256Ctx = {};
+
+                if (sha256Init(verifySha256Ctx) != 0) {
+                    throw std::string("Failed to initalize hasher");
+                }
 
                 while (readSize < writtenSize) {
                     size_t bufferSize = (maxBufferSize > 0) ? maxBufferSize : writtenSize;

--- a/sha256.h
+++ b/sha256.h
@@ -25,6 +25,10 @@
 #include <string>
 #include <array>
 
+#ifdef USE_KERNEL_CRYPTO_API
+#include <kcapi.h>
+#endif
+
 // SHA256 constants
 constexpr uint32_t k[64] = {
     0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
@@ -46,10 +50,15 @@ struct SHA256Ctx {
     uint64_t bitLength = 0;
     std::array<uint8_t, 64> dataBlock{};
     size_t dataBlockIndex = 0;
+#ifdef USE_KERNEL_CRYPTO_API
+    struct kcapi_handle *handle = nullptr;
+#endif
+    bool initialized = false;
 };
 
 // Public functions
-void sha256Update(SHA256Ctx& context, const std::string& data);
+int sha256Init(SHA256Ctx& context);
+int sha256Update(SHA256Ctx& context, const std::string& data);
 std::string sha256Finalize(SHA256Ctx& context);
 
 #endif // SHA256_H


### PR DESCRIPTION
Add the possibility to enable support for the Linux kernel crypto API, which allows to perform the SHA256 operations exploiting the facilities exposed by the kernel, including hardware accelerators.
