### PR TITLE
CMakeLists.txt: use static libarchive flags when needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,32 @@ pkg_check_modules(LIBARCHIVE REQUIRED libarchive)
 if (LIBARCHIVE_FOUND)
     include_directories(${LIBARCHIVE_INCLUDE_DIRS})
     link_directories(${LIBARCHIVE_LIBRARY_DIRS})
+
+    set(BMAP_WRITER_LIBARCHIVE_LIBS ${LIBARCHIVE_LDFLAGS})
+    set(BMAP_WRITER_USE_STATIC_LIBARCHIVE FALSE)
+
+    foreach(lib ${LIBARCHIVE_LINK_LIBRARIES})
+        if (lib MATCHES "\\.a$")
+            set(BMAP_WRITER_USE_STATIC_LIBARCHIVE TRUE)
+            break()
+        endif()
+    endforeach()
+
+    if (NOT BMAP_WRITER_USE_STATIC_LIBARCHIVE)
+        foreach(libdir ${LIBARCHIVE_LIBRARY_DIRS})
+            if (EXISTS "${libdir}/libarchive.a" AND
+                NOT EXISTS "${libdir}/libarchive.so" AND
+                NOT EXISTS "${libdir}/libarchive.so.0" AND
+                NOT EXISTS "${libdir}/libarchive.dylib")
+                set(BMAP_WRITER_USE_STATIC_LIBARCHIVE TRUE)
+                break()
+            endif()
+        endforeach()
+    endif()
+
+    if (BMAP_WRITER_USE_STATIC_LIBARCHIVE)
+        set(BMAP_WRITER_LIBARCHIVE_LIBS ${LIBARCHIVE_STATIC_LDFLAGS})
+    endif()
 else()
     message(FATAL_ERROR "libarchive not found")
 endif()
@@ -60,7 +86,7 @@ add_executable(bmap-writer bmap-writer.cpp sha256.cpp)
 target_compile_options(bmap-writer PUBLIC -Wformat -Wformat-security -Wconversion -Wsign-conversion -pedantic -Werror)
 
 # Link the libraries
-target_link_libraries(bmap-writer ${TINYXML2_LIBRARIES} ${LIBARCHIVE_LIBRARIES} ${CRYPTO_LIBRARIES})
+target_link_libraries(bmap-writer ${TINYXML2_LIBRARIES} ${BMAP_WRITER_LIBARCHIVE_LIBS} ${CRYPTO_LIBRARIES})
 
 # Specify the install rules
 install(TARGETS bmap-writer DESTINATION bin)


### PR DESCRIPTION
  ## Summary

  This change fixes static linking of `bmap-writer` when `libarchive` is only
  available as a static archive.

  The project already uses `pkg-config` for `libarchive`, but it always links
  with the normal `LIBARCHIVE_*` result. In static-only layouts, that is not
  enough: `libarchive.a` also requires its private backend dependencies such as
  `zlib`, `bzip2`, `lz4`, `liblzma`, and `zstd`.

  This patch keeps the normal link flags for shared-capable layouts and switches
  to the static `pkg-config` flags only when the discovered `libarchive`
  installation is effectively static-only.

  ## Why this is needed

  Without this change, a static-only toolchain can fail at the final link step
  with undefined references from `libarchive.a`, for example to symbols from:

  - `zlib`
  - `bzip2`
  - `lz4`
  - `liblzma`
  - `zstd`

  ## Behavior after this change

  - Shared-capable `libarchive` layouts keep using the normal link flags
  - Static-only `libarchive` layouts use the static `pkg-config` link flags
  - This avoids pulling extra private dependencies into the shared-capable case

  ## Testing

  I tested this in three ways:

  1. Real cross-build against a static Buildroot toolchain/sysroot
     - Before the change, the build failed at link time with missing symbols from
       `libarchive` compression backends
     - After the change, the build completed successfully

  2. Synthetic shared-layout `pkg-config` setup
     - Verified that the generated link line keeps using only the normal
       `libarchive` flags

  3. Synthetic static-layout `pkg-config` setup
     - Verified that the generated link line switches to the static `pkg-config`
       flags and includes the extra private dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system flexibility for libarchive linking, improving detection and selection between static and dynamic library configurations during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->