### PR TITLE
fix: use exact match for mount check

### DIFF
--- a/bmap-writer.cpp
+++ b/bmap-writer.cpp
@@ -233,7 +233,7 @@ bool isDeviceMounted(const std::string &device) {
     std::ifstream mounts("/proc/mounts");
     std::string line;
     while (std::getline(mounts, line)) {
-        if (line.find(device) != std::string::npos) {
+        if (line.compare(0, device.size() + 1, device + " ") == 0) {
             return true;
         }
     }


### PR DESCRIPTION
isDeviceMounted use string find which will return true if the mount points prefix are same.
fix by exact match: device + space

Thank you for contributing to `bmap-writer`!

By submitting this pull request, you confirm that:
- This contribution is your original work or you have the necessary rights to submit it.
- You agree to the terms outlined in the project's Contributor License Agreement (CLA).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device mount detection to avoid matching unrelated device paths in system mount information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->